### PR TITLE
fix: 支持从外部设置Page的超时时间timeout

### DIFF
--- a/packages/juejin-helper/src/utils/browser.ts
+++ b/packages/juejin-helper/src/utils/browser.ts
@@ -27,7 +27,8 @@ export default class JuejinBrowser {
   async visitPage(path: string = "", options = {}): Promise<Page> {
     const opts = Object.assign(
       {
-        viewport: { width: 414, height: 820 }
+        viewport: { width: 414, height: 820 },
+        timeout: 30000
       },
       options
     );
@@ -36,6 +37,7 @@ export default class JuejinBrowser {
     const page = await browser.newPage();
 
     await page.setViewport(opts.viewport);
+    page.setDefaultTimeout(opts.timeout);
 
     const cookiesString = this.juejin.cookie.toString();
     const cookiesArray = cookiesString.split(/;\W+/).map(item => item.split("="));


### PR DESCRIPTION
- puppeteer 默认超时时间为 30s
- 网络环境较差时 访问超时时间过短
- 出现访问超时报错: `TimeoutError: Navigation timeout of 30000 ms exceeded`
- Page未提供统一设置options的方法 通过`setDefaultTimeout`设置超时时间
